### PR TITLE
Use win32surface by default

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -10,9 +10,9 @@ import bindbc.loader;
 import erupted;
 
 import common;
-import glfwsurfaceprovider;
 import imagebarrier;
 import vulkancontext;
+import win32surfaceprovider;
 
 interface ISampleApp
 {
@@ -92,6 +92,7 @@ void main()
     {
         const rc = loadGLFW("lib/glfw3.dll");
         assert(rc == glfwSupport);
+        assert(loadGLFW_Windows);
     }
     assert(glfwInit() != 0);
     scope (exit) glfwTerminate();
@@ -104,17 +105,14 @@ void main()
     assert(window !is null);
     scope(exit) glfwDestroyWindow(window);
 
-    auto surfaceProvider = new GLFWSurfaceProvider(window);
+    auto surfaceProvider = new Win32SurfaceProvider(window);
 
     auto vulkanCtx = VulkanContext.get();
     scope(exit) vulkanCtx.cleanup();
-    writeln("initialize vulkan context");
     vulkanCtx.initialize("Triangle", surfaceProvider);
-    writeln("recreate swapchain");
     vulkanCtx.recreateSwapchain();
 
     auto theApp = new TriangleApp;
-    writeln("initialize app");
     theApp.onInitialize();
     scope(exit) theApp.onCleanup();
 

--- a/source/swapchain.d
+++ b/source/swapchain.d
@@ -19,7 +19,7 @@ public:
         auto surface = vulkanCtx.getSurface();
 
         VkSurfaceCapabilitiesKHR caps;
-        vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vkPhysicalDevice, surface, &caps);
+        enforceVK(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vkPhysicalDevice, surface, &caps));
         VkExtent2D extent = caps.currentExtent;
         if (extent.width == uint.max)
         {
@@ -28,13 +28,13 @@ public:
         }
 
         uint count;
-        vkGetPhysicalDeviceSurfaceFormatsKHR(
+        enforceVK(vkGetPhysicalDeviceSurfaceFormatsKHR(
             vkPhysicalDevice, surface, &count, null
-        );
+        ));
         auto formats = new VkSurfaceFormatKHR[](count);
-        vkGetPhysicalDeviceSurfaceFormatsKHR(
+        enforceVK(vkGetPhysicalDeviceSurfaceFormatsKHR(
             vkPhysicalDevice, surface, &count, formats.ptr
-        );
+        ));
 
         VkSurfaceFormatKHR format = formats[0];
         foreach (surfaceFormat; formats)
@@ -70,7 +70,7 @@ public:
         info.oldSwapchain = m_swapchain;
 
         // GPUがidle状態になってからswapchainの(再)作成
-        vkDeviceWaitIdle(vkDevice);
+        enforceVK(vkDeviceWaitIdle(vkDevice));
 
         VkSwapchainKHR swapchain;
         enforceVK(vkCreateSwapchainKHR(vkDevice, &info, null, &swapchain));

--- a/source/vulkancontext.d
+++ b/source/vulkancontext.d
@@ -3,7 +3,6 @@ module vulkancontext;
 version(Windows) import core.sys.windows.windows;
 import core.stdc.stdio : printf, snprintf;
 import std.concurrency : initOnce;
-import std.stdio;
 
 import erupted;
 
@@ -35,9 +34,7 @@ public:
         createInstance(appName);
         common.loadInstanceLevelFunctions(m_vkInstance);
         pickPhysicalDevice();
-        writeln("get device");
         createLogicalDevice();
-        writeln("create command pool");
         createCommandPool();
     }
 
@@ -246,13 +243,11 @@ private:
         deviceInfo.pNext = &m_physDevFeatures;
         deviceInfo.pEnabledFeatures = null;
 
-        writeln("vkCreateDevice");
         enforceVK(vkCreateDevice(m_vkPhysicalDevice, &deviceInfo, null, &m_vkDevice));
         assert(m_vkDevice !is null);
 
         loadDeviceLevelFunctionsExtI(m_vkInstance);
 
-        writeln("vkGetDeviceQueue");
         vkGetDeviceQueue(m_vkDevice, m_graphicsQueueFamilyIndex, 0, &m_graphicsQueue);
     }
 
@@ -283,12 +278,12 @@ private:
 
         // グラフィクスキューがこのサーフェースにPresentを発行できるか
         VkBool32 present = VK_FALSE;
-        vkGetPhysicalDeviceSurfaceSupportKHR(
+        enforceVK(vkGetPhysicalDeviceSurfaceSupportKHR(
             m_vkPhysicalDevice,
             m_graphicsQueueFamilyIndex,
             m_surface,
             &present
-        );
+        ));
         assert(present != VK_FALSE, "not supported presentation");
     }
 

--- a/source/win32surfaceprovider.d
+++ b/source/win32surfaceprovider.d
@@ -1,0 +1,48 @@
+module win32surfaceprovider;
+
+version(Windows):
+
+import core.sys.windows.windows;
+
+import bindbc.glfw;
+import erupted;
+
+import common;
+import isurfaceprovider;
+
+class Win32SurfaceProvider : ISurfaceProvider
+{
+    this(GLFWwindow* window)
+    {
+        m_window = window;
+    }
+
+    VkSurfaceKHR createSurface(VkInstance instance)
+    {
+        assert(loadGLFW_Windows);
+        VkWin32SurfaceCreateInfoKHR createInfo = {
+            hinstance: GetModuleHandle(null),
+            hwnd: glfwGetWin32Window(m_window)
+        };
+        VkSurfaceKHR surface;
+        enforceVK(vkCreateWin32SurfaceKHR(instance, &createInfo, null, &surface));
+        return surface;
+    }
+
+    uint getFrameBufferWidth()
+    {
+        int width;
+        glfwGetFramebufferSize(m_window, &width, null);
+        return cast(uint) width;
+    }
+
+    uint getFrameBufferHeight()
+    {
+        int height;
+        glfwGetFramebufferSize(m_window, null, &height);
+        return cast(uint) height;
+    }
+
+private:
+    GLFWwindow* m_window;
+}


### PR DESCRIPTION
~~EDIT: This doesn't fix #3, need to fix the root cause.~~

The root cause of #3 is missing `loadGLFW_Windows`, however glfwCreateWindowSurface didn't work for me so switches to win32surface by default.